### PR TITLE
fix for getgems listing : pass ownerAddress in nftSale dataCell

### DIFF
--- a/src/contracts/NftSale.ts
+++ b/src/contracts/NftSale.ts
@@ -74,7 +74,7 @@ export class NftSale {
     dataCell.storeUint(saleData.createdAt, 32);
     dataCell.storeAddress(saleData.marketplaceAddress);
     dataCell.storeAddress(saleData.nftAddress);
-    dataCell.storeAddress(null);
+    dataCell.storeAddress(saleData.nftOwnerAddress);
     dataCell.storeCoins(saleData.fullPrice);
     dataCell.storeRef(feesCell.endCell());
 


### PR DESCRIPTION
While deploying the sale contract, The ownerAddress field in sale contract data cell is passed as null, which will deploy the contract, but sites like getGems.io won't be aple to identify that its on sale. 